### PR TITLE
Correct quickstart instructions

### DIFF
--- a/src/views/docs/en/get-started/quickstart.md
+++ b/src/views/docs/en/get-started/quickstart.md
@@ -9,13 +9,13 @@ description: Get started quickly with Architect
 Assuming Node.js 14+ is installed, open your terminal and create a new Architect project:
 
 ```bash
-npm init @architect new-app
+npm exec @architect/create your-app
 ```
 
 Start the local dev server:
 
 ```bash
-cd new-app
+cd your-app
 npx arc sandbox
 ```
 > `Cmd / Ctrl + c` exits the sandbox


### PR DESCRIPTION
The docs say `npm init @architect new-app` but that does not work, because `npm init` will try to run `@architect/create-new-app`.

I had to use `npm exec @architect/create new-app` to get it to create a folder called `new-app`. Updating the docs with the correct instruction. Also using `your-app` so it's clear that `new-app` is not some kind of keyword.
